### PR TITLE
Corrected the order of destroy_all in the seeds to prevent conflict w…

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.1].define(version: 2025_02_13_111547) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,12 +9,12 @@
 #   end
 
 puts "Cleaning database..."
-User.destroy_all
-Sandwich.destroy_all
-Ingredient.destroy_all
-Trait.destroy_all
 IngredientTrait.destroy_all
 SandwichIngredient.destroy_all
+Trait.destroy_all
+Ingredient.destroy_all
+Sandwich.destroy_all
+User.destroy_all
 
 puts "Creating users..."
 users = [


### PR DESCRIPTION
The destroy_add methods in the seed header were mis-ordered so running the seeds would try to delete a model before it's dependent foreign keys. Order now corrected.