### PR TITLE
Changed styling for ingredient container

### DIFF
--- a/app/assets/stylesheets/pages/_sandwiches.scss
+++ b/app/assets/stylesheets/pages/_sandwiches.scss
@@ -209,63 +209,49 @@
   font-size: 40px;
 }
 
-// Chalkboard Style for Sandwich Sections (Mobile Optimized, No Hover Effects)
 .sandwich-card.ingredients-card {
-  background-color: #2f4f2f; // Dark green chalkboard background
+  background: transparent;
+  color: rgb(255, 191, 0);
+  border-radius: 12px;
   padding: 20px;
-  margin-bottom: 20px;
-  border-radius: 10px;
+  width: 100%;
+  max-width: 400px;
   box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
-  font-family: 'Courier New', Courier, monospace; // Chalky font style
-  color: white;
-  background-image: url('https://www.transparenttextures.com/patterns/dark-matter.png'); // Subtle chalkboard texture
-  background-size: cover;
-
-  // Brighter wood color for the border
-  border: 10px solid #683700; // Lighter wood color (Tan / Light Brown)
-
-  background-clip: padding-box; // Prevents the background from extending into the border area
-  padding: 20px; // Adjust padding to prevent gap inside
+  margin: 10px 15px;
 }
 
-// Sandwich Card Header Style
 .sandwich-card.ingredients-card h2 {
-  font-size: 1.5rem; // Smaller font size for mobile
+  font-size: 1.5rem;
   font-weight: bold;
   text-align: center;
-  color: #ffffff;
+  color: rgb(255, 191, 0);
   margin-bottom: 15px;
   text-transform: uppercase;
-  font-family: 'Rock Salt', cursive; // Chalky font for headers
 }
 
-// Single Green Box for Ingredients
 .sandwich-card.ingredients-card .ingredients-container {
-  background-color: #2f4f2f; // Dark green chalkboard background
-  padding: 15px;
-  box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
-  color: white;
-  font-family: 'Courier New', Courier, monospace;
   display: flex;
   flex-direction: column;
   align-items: center;
-  flex-wrap: wrap;
-  gap: 10px; // Space between ingredients
-  border: none; // Ensure no white borders inside the box
-  background-image: url('https://www.transparenttextures.com/patterns/dark-matter.png'); // Subtle chalkboard texture
-  background-size: cover;
+  gap: 10px;
 }
 
-// Ingredient Items inside the Green Box
-.sandwich-card.ingredients-card .ingredients-container .ingredient-item {
-  font-size: 1.1rem; // Adjust font size for mobile screens
-  font-family: 'Rock Salt', cursive; // Chalky font style for ingredients
-  color: #ffffff;
-  padding: 8px 12px;
-  display: block;
+.ingredient-item {
+  border: 2px dotted rgb(255, 191, 0);
+  border-radius: 8px;
+  padding: 10px 15px;
+  font-size: 1.1rem;
+  font-family: inherit;
+  color: rgb(255, 191, 0);
   text-align: center;
   text-transform: capitalize;
-  position: relative; // Allow positioning for the bottom line
+  min-width: 250px;
+  width: 300px;
+  height: 50px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  white-space: nowrap;
 }
 
 .sandwich-card.empty-card {

--- a/app/views/sandwiches/show.html.erb
+++ b/app/views/sandwiches/show.html.erb
@@ -59,8 +59,7 @@
   <div class="ingredients-container">
     <% @sandwich.ingredients.each do |ingredient| %>
       <div class="ingredient-item">
-        <strong><%= ingredient.name %></strong>
-        (<%= ingredient.unit_of_measure %>)
+        <strong><%= "#{ingredient.name} - #{ingredient.unit_of_measure}" %></strong>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
Got rid of the beta design of ingredients that looked like chalkboard.
Added similar styling from creating a new sandwich.

Changed files: HMTL, SCSS
Html:
Display name of the sandwich with  unites of measure.

Scss:
Removed previous code for the design and implemented with similar code from new sandwich create.