### PR TITLE
Ingredients images

### DIFF
--- a/app/assets/stylesheets/pages/_sandwiches.scss
+++ b/app/assets/stylesheets/pages/_sandwiches.scss
@@ -218,7 +218,7 @@
   width: 100%;
   max-width: 400px;
   box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
-  margin: 10px 15px;
+  margin: 10px auto;
 }
 
 .sandwich-card.ingredients-card h2 {

--- a/app/assets/stylesheets/pages/_sandwiches.scss
+++ b/app/assets/stylesheets/pages/_sandwiches.scss
@@ -5,7 +5,7 @@
 .card {
   margin: 10px 15px;
   border-radius: 12px;
-  box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1);
+  box-shadow: 0px 4px 6px rgba(255, 255, 255, 0.1);
   padding: 20px;
 }
 
@@ -212,7 +212,8 @@
 .sandwich-card.ingredients-card {
   background: transparent;
   color: rgb(255, 191, 0);
-  border-radius: 12px;
+  border: 3px solid #86613d;
+  border-radius: 0px;
   padding: 20px;
   width: 100%;
   max-width: 400px;
@@ -237,21 +238,54 @@
 }
 
 .ingredient-item {
-  border: 2px dotted rgb(255, 191, 0);
-  border-radius: 8px;
+  border: 2px dotted #86613d;
+  border-radius: 0px;
   padding: 10px 15px;
   font-size: 1.1rem;
   font-family: inherit;
   color: rgb(255, 191, 0);
-  text-align: center;
-  text-transform: capitalize;
-  min-width: 250px;
-  width: 300px;
-  height: 50px;
+  text-align: left;
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
   align-items: center;
-  white-space: nowrap;
+  gap: 10px;
+  min-width: 250px;
+  width: 350px;
+  height: auto;
+  white-space: normal;
+  word-wrap: break-word;
+}
+
+.ingredient-image {
+  width: 100px;
+  height: 100px;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.ingredient-details {
+  flex-grow: 1;
+  font-size: 1.1rem;
+  font-family: inherit;
+}
+
+.ingredient-name {
+  font-weight: bold;
+  margin: 0;
+  padding: 0;
+  border: none !important;
+  background: none !important;
+}
+
+.ingredient-divider {
+  border-top: 1px solid #86613d;
+  margin-top: 5px;
+  margin-bottom: 10px;
+}
+
+.ingredient-unit {
+  font-size: 1rem;
+  display: block;
 }
 
 .sandwich-card.empty-card {

--- a/app/views/sandwiches/show.html.erb
+++ b/app/views/sandwiches/show.html.erb
@@ -55,11 +55,21 @@
 </div>
 
 <div class="card p-3 mb-3 sandwich-card ingredients-card">
-  <h2>Ingredients:</h2>
   <div class="ingredients-container">
     <% @sandwich.ingredients.each do |ingredient| %>
       <div class="ingredient-item">
-        <strong><%= "#{ingredient.name} - #{ingredient.unit_of_measure}" %></strong>
+        <div class="ingredient-image">
+          <%= image_tag(Cloudinary::Utils.cloudinary_url(ingredient.image_url), alt: ingredient.name, width: "100", height: "100") %>
+        </div>
+        <div class="ingredient-details">
+          <div class="ingredient-name">
+            <%= ingredient.name %>
+          </div>
+          <div class="ingredient-divider"></div>
+          <span class="ingredient-unit">
+            <%= ingredient.unit_of_measure %>
+          </span>
+        </div>
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
worked on the styling for show page ingredient container.
1. Did minor changes to html structure to display name, texture notes and ingredients according to Figma.
2. Minor changes of gapping for Tasting notes to align boxes together.
3. Overall design of the Ingredients.
![Screenshot 2025-02-21 000602](https://github.com/user-attachments/assets/2a504a4e-06cb-4723-af6b-4daa0df03042)
![Screenshot 2025-02-21 000547](https://github.com/user-attachments/assets/a623cea1-1c1f-4106-9b4f-04377e1a4e1d)
