### PR TITLE
Fixed description not being shown for new sandwich

### DIFF
--- a/app/controllers/sandwiches_controller.rb
+++ b/app/controllers/sandwiches_controller.rb
@@ -48,7 +48,7 @@ class SandwichesController < ApplicationController
   end
 
   def create
-    @sandwich = Sandwich.new(sandwich_params.slice(:name, :photo))
+    @sandwich = Sandwich.new(sandwich_params.slice(:name, :description, :photo))
     @sandwich.user = @user  # Ensure the sandwich is associated with the current user
     if @sandwich.save
       sandwich_params[:ingredient_ids].each_with_index do |ingredient_id, index|
@@ -89,6 +89,6 @@ class SandwichesController < ApplicationController
 
   # Define permitted parameters for the sandwich form
   def sandwich_params
-    params.require(:sandwich).permit(:name, :photo, ingredient_ids: [], ingredient_quantities: {})
+    params.require(:sandwich).permit(:name, :description, :photo, ingredient_ids: [], ingredient_quantities: {})
   end
 end

--- a/app/views/sandwiches/new.html.erb
+++ b/app/views/sandwiches/new.html.erb
@@ -45,7 +45,7 @@
     </div>
 
     <div class="mb-3">
-      <%= f.input :description, as: :text, label: "Sandwich Description", input_html: { class: 'form-control', rows: 4 } %>
+      <%= f.input :description, as: :text, label: "Sandwich Description:", input_html: { class: 'form-control', rows: 4 } %>
     </div>
 
     <div class="mb-3">
@@ -58,3 +58,5 @@
     </div>
   <% end %>
 </div>
+
+<div class="p-3 mb-3 empty-card-create"></div>


### PR DESCRIPTION
Worked on displaying description for the new sandwich.
Added an empty card at the bottom of the page so that the text for "Create a sandwich" is not going anymore below the footer.
![Screenshot 2025-02-21 201424](https://github.com/user-attachments/assets/17ba51f5-54a9-4764-af76-2a300067461b)

