### PR TITLE
adding the missing acts-as-taggable-on gem to the gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,5 +78,5 @@ group :test do
 end
 
 gem 'acts_as_favoritor'
-
+gem 'acts-as-taggable-on'
 gem 'faker'


### PR DESCRIPTION
Gem was missing from last push. This should correctly add it.